### PR TITLE
タグの並べ替えに関するAPI定義の追加

### DIFF
--- a/spec.yml
+++ b/spec.yml
@@ -1200,6 +1200,7 @@ components:
           type: string
         position:
           type: integer
+          minimum: 0
 
     TagPositionOnly:
       type: object
@@ -1212,6 +1213,7 @@ components:
           format: uuid
         position:
           type: integer
+          minimum: 0
 
     TagIdOnly:
       type: object

--- a/spec.yml
+++ b/spec.yml
@@ -423,6 +423,7 @@ paths:
 
     post:
       summary: タグを作成する
+      description: 新しいタグは末尾に追加されます
       tags:
         - タグ
       requestBody:
@@ -442,6 +443,35 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/Tag"
+        400:
+          $ref: '#/components/responses/BadRequestError'
+        401:
+          $ref: '#/components/responses/UnauthorizedError'
+        500:
+          $ref: '#/components/responses/InternalServerError'
+    patch:
+      summary: タグを並べ替える
+      description: |-
+        positionを変更するタグのidとpositionの配列を送信してください。
+        positionが重複している場合はエラーになります。
+      tags:
+      - タグ
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: array
+              items:
+                $ref: '#/components/schemas/TagPositionOnly'
+      responses:
+        200:
+          description: 成功
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/TagPositionOnly'
         400:
           $ref: '#/components/responses/BadRequestError'
         401:
@@ -1168,6 +1198,20 @@ components:
           format: uuid
         name:
           type: string
+        position:
+          type: integer
+
+    TagPositionOnly:
+      type: object
+      required:
+        - id
+        - position
+      properties:
+        id:
+          type: string
+          format: uuid
+        position:
+          type: integer
 
     TagIdOnly:
       type: object


### PR DESCRIPTION
- tagのデータにpositionを追加
- tags/patch で並べ替え後のpositionを指定すると並べ替えができる
- tags/post では、そのユーザーが持つタグのpositionの最大値+1の値が自動設定される